### PR TITLE
Mat3 and Mat4 #multiply! now type-checks from main scope

### DIFF
--- a/lib/snow-math/mat3.rb
+++ b/lib/snow-math/mat3.rb
@@ -121,8 +121,8 @@ class Snow::Mat3
   #
   def multiply!(rhs)
     multiply rhs, case rhs
-      when Mat3, Numeric then self
-      when Vec3 then rhs
+      when ::Snow::Mat3, Numeric then self
+      when ::Snow::Vec3 then rhs
       else raise TypeError, "Invalid type for RHS"
       end
   end

--- a/lib/snow-math/mat4.rb
+++ b/lib/snow-math/mat4.rb
@@ -126,8 +126,8 @@ class Snow::Mat4
   # #multiply(rhs, rhs).
   def multiply!(rhs)
     multiply rhs, case rhs
-      when Mat4, Numeric then self
-      when Vec4, Vec3 then rhs
+      when ::Snow::Mat4, Numeric then self
+      when ::Snow::Vec4, ::Snow::Vec3 then rhs
       else raise TypeError, "Invalid type for RHS"
       end
   end


### PR DESCRIPTION
This fixes an `undefined constant` issue when trying to use `multiply!` with Snow classes.

Closes #2.